### PR TITLE
Allow clearing cache of memoized function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ module.exports = (fn, opts) => {
 			throw err;
 		});
 	};
+	
+        ret.clear = () => mem.clear(memoized);
 
 	mimicFn(ret, fn);
 


### PR DESCRIPTION
Useful to still be able to clear the cache.