### PR TITLE
Add support for async cache

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
-declare namespace mem {
+type MaybePromise<T> = Promise<T> | T;
+declare namespace pMemoize {
 	interface CacheStorage<KeyType, ValueType> {
-		has(key: KeyType): boolean;
-		get(key: KeyType): ValueType | undefined;
-		set(key: KeyType, value: ValueType): void;
-		delete(key: KeyType): void;
-		clear?: () => void;
+		has(key: KeyType): MaybePromise<boolean>;
+		get(key: KeyType): MaybePromise<ValueType | undefined>;
+		set(key: KeyType, value: ValueType): MaybePromise<void>;
+		delete(key: KeyType): MaybePromise<void>;
+		clear?: () => MaybePromise<void>;
 	}
 
 	interface Options<
@@ -56,7 +57,7 @@ declare namespace mem {
 	}
 }
 
-declare const mem: {
+declare const pMemoize: {
 	/**
 	[Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input.
 
@@ -92,7 +93,7 @@ declare const mem: {
 		FunctionToMemoize = (...arguments: ArgumentsType) => ReturnType
 	>(
 		fn: FunctionToMemoize,
-		options?: mem.Options<ArgumentsType, CacheKeyType, ReturnType>
+		options?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
 	): FunctionToMemoize;
 
 	/**
@@ -102,7 +103,7 @@ declare const mem: {
 	*/
 	clear<ArgumentsType extends unknown[], ReturnType>(
 		fn: (...arguments: ArgumentsType) => ReturnType
-	): void;
+	): Promise<void>;
 };
 
-export = mem;
+export = pMemoize;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,54 +1,108 @@
-import {Options as MemOptions} from 'mem';
+declare namespace mem {
+	interface CacheStorage<KeyType, ValueType> {
+		has(key: KeyType): boolean;
+		get(key: KeyType): ValueType | undefined;
+		set(key: KeyType, value: ValueType): void;
+		delete(key: KeyType): void;
+		clear?: () => void;
+	}
 
-declare namespace pMemoize {
-	type Options<
+	interface Options<
 		ArgumentsType extends unknown[],
 		CacheKeyType,
 		ReturnType
-	> = MemOptions<ArgumentsType, CacheKeyType, ReturnType>;
-}
-declare const pMemoize: {
-	/**
-	[Memoize](https://en.wikipedia.org/wiki/Memoization) promise-returning & async functions.
+	> {
+		/**
+		Milliseconds until the cache expires.
 
-	@param fn - Promise-returning or async function to be memoized.
-	@param memoizeOptions - See the [`mem` options](https://github.com/sindresorhus/mem#options).
-	@returns A memoized version of the `input` function.
+		@default Infinity
+		*/
+		readonly maxAge?: number;
+
+		/**
+		Determines the cache key for storing the result based on the function arguments. By default, __only the first argument is considered__ and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
+
+		A `cacheKey` function can return any type supported by `Map` (or whatever structure you use in the `cache` option).
+
+		You can have it cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
+
+		```
+		import mem = require('mem');
+
+		mem(function_, {cacheKey: JSON.stringify});
+		```
+
+		Or you can use a more full-featured serializer like [serialize-javascript](https://github.com/yahoo/serialize-javascript) to add support for `RegExp`, `Date` and so on.
+
+		```
+		import mem = require('mem');
+		import serializeJavascript = require('serialize-javascript');
+
+		mem(function_, {cacheKey: serializeJavascript});
+		```
+
+		@default arguments_ => arguments_[0]
+		@example arguments_ => JSON.stringify(arguments_)
+		*/
+		readonly cacheKey?: (arguments: ArgumentsType) => CacheKeyType;
+
+		/**
+		Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
+
+		@default new Map()
+		@example new WeakMap()
+		*/
+		readonly cache?: CacheStorage<CacheKeyType, {data: ReturnType; maxAge: number}>;
+	}
+}
+
+declare const mem: {
+	/**
+	[Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input.
+
+	@param fn - Function to be memoized.
 
 	@example
 	```
-	import pMemoize = require('p-memoize');
-	import got = require('got');
+	import mem = require('mem');
 
-	const memGot = pMemoize(got, {maxAge: 1000});
+	let i = 0;
+	const counter = () => ++i;
+	const memoized = mem(counter);
 
-	(async () => {
-		memGot('sindresorhus.com');
+	memoized('foo');
+	//=> 1
 
-		// This call is cached
-		memGot('sindresorhus.com');
+	// Cached as it's the same arguments
+	memoized('foo');
+	//=> 1
 
-		setTimeout(() => {
-			// This call is not cached as the cache has expired
-			memGot('sindresorhus.com');
-		}, 2000);
-	})();
+	// Not cached anymore as the arguments changed
+	memoized('bar');
+	//=> 2
+
+	memoized('bar');
+	//=> 2
 	```
 	*/
-	<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
-		fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-		memoizeOptions?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
-	): (...arguments: ArgumentsType) => Promise<ReturnType>;
+	<
+		ArgumentsType extends unknown[],
+		ReturnType,
+		CacheKeyType,
+		FunctionToMemoize = (...arguments: ArgumentsType) => ReturnType
+	>(
+		fn: FunctionToMemoize,
+		options?: mem.Options<ArgumentsType, CacheKeyType, ReturnType>
+	): FunctionToMemoize;
 
 	/**
 	Clear all cached data of a memoized function.
 
-	@param memoized - A function that was previously memoized. Will throw if passed a non-memoized function.
+	@param fn - Memoized function.
 	*/
-	clear(memoized: (...arguments: unknown[]) => unknown): void;
-
-	// TODO: Remove this for the next major release
-	default: typeof pMemoize;
+	clear<ArgumentsType extends unknown[], ReturnType>(
+		fn: (...arguments: ArgumentsType) => ReturnType
+	): void;
 };
 
-export = pMemoize;
+export = mem;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const mapAgeCleaner = require('map-age-cleaner');
 
 const cacheStore = new WeakMap();
 
-const mem = (fn, {
+const pMemoize = (fn, {
 	cacheKey = ([firstArgument]) => firstArgument,
 	cache = new Map(),
 	maxAge
@@ -13,16 +13,16 @@ const mem = (fn, {
 		mapAgeCleaner(cache);
 	}
 
-	const memoized = function (...arguments_) {
+	const memoized = async function (...arguments_) {
 		const key = cacheKey(arguments_);
 
-		if (cache.has(key)) {
-			return cache.get(key).data;
+		if (await cache.has(key)) {
+			return (await cache.get(key)).data;
 		}
 
 		const cacheItem = fn.apply(this, arguments_);
 
-		cache.set(key, {
+		await cache.set(key, {
 			data: cacheItem,
 			maxAge: maxAge ? Date.now() + maxAge : Infinity
 		});
@@ -41,15 +41,15 @@ const mem = (fn, {
 	return memoized;
 };
 
-module.exports = mem;
+module.exports = pMemoize;
 
-module.exports.clear = fn => {
+module.exports.clear = async fn => {
 	if (!cacheStore.has(fn)) {
 		throw new Error('Can\'t clear a function that was not memoized!');
 	}
 
 	const cache = cacheStore.get(fn);
 	if (typeof cache.clear === 'function') {
-		cache.clear();
+		await cache.clear();
 	}
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const pMemoize = (fn, {
 			return (await cache.get(key)).data;
 		}
 
-		const cacheItem = fn.apply(this, arguments_);
+		const cacheItem = await fn.apply(this, arguments_);
 
 		await cache.set(key, {
 			data: cacheItem,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,29 +1,31 @@
 import {expectType} from 'tsd';
-import mem = require('.');
+import pMemoize = require('.');
 
-const fn = (string: string) => true;
+const fn = async (string: string) => true;
 
-expectType<(string: string) => boolean>(mem(fn));
-expectType<(string: string) => boolean>(mem(fn, {maxAge: 1}));
-expectType<(string: string) => boolean>(mem(fn, {cacheKey: (...arguments_) => arguments_}));
-expectType<(string: string) => boolean>(
-	mem(
+expectType<typeof fn>(pMemoize(fn));
+expectType<typeof fn>(pMemoize(fn, {maxAge: 1}));
+expectType<typeof fn>(pMemoize(fn, {cacheKey: (...arguments_) => arguments_}));
+expectType<typeof fn>(
+	pMemoize(
 		fn,
 		{cacheKey: (arguments_) => arguments_,
 		cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
-expectType<(string: string) => boolean>(
-	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
+expectType<typeof fn>(
+	pMemoize(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
 
 /* Overloaded function tests */
-function overloadedFn(parameter: false): false;
-function overloadedFn(parameter: true): true;
-function overloadedFn(parameter: boolean): boolean {
+async function overloadedFn(parameter: false): Promise<false>;
+async function overloadedFn(parameter: true): Promise<true>;
+async function overloadedFn(parameter: boolean): Promise<boolean> {
 	return parameter;
 }
-expectType<typeof overloadedFn>(mem(overloadedFn));
-expectType<true>(mem(overloadedFn)(true));
-expectType<false>(mem(overloadedFn)(false));
+expectType<typeof overloadedFn>(pMemoize(overloadedFn));
+(async () => {
+	expectType<true>(await pMemoize(overloadedFn)(true));
+	expectType<false>(await pMemoize(overloadedFn)(false));
+})();
 
-mem.clear(fn);
+pMemoize.clear(fn);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,29 @@
 import {expectType} from 'tsd';
-import pMemoize = require('.');
+import mem = require('.');
 
-expectType<(name: string) => Promise<string>>(
-	pMemoize(async (name: string) => `Hello ${name}!`)
+const fn = (string: string) => true;
+
+expectType<(string: string) => boolean>(mem(fn));
+expectType<(string: string) => boolean>(mem(fn, {maxAge: 1}));
+expectType<(string: string) => boolean>(mem(fn, {cacheKey: (...arguments_) => arguments_}));
+expectType<(string: string) => boolean>(
+	mem(
+		fn,
+		{cacheKey: (arguments_) => arguments_,
+		cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
-expectType<() => Promise<number>>(pMemoize(async () => 1));
+expectType<(string: string) => boolean>(
+	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
+);
 
-pMemoize(async () => 1, {maxAge: 1});
+/* Overloaded function tests */
+function overloadedFn(parameter: false): false;
+function overloadedFn(parameter: true): true;
+function overloadedFn(parameter: boolean): boolean {
+	return parameter;
+}
+expectType<typeof overloadedFn>(mem(overloadedFn));
+expectType<true>(mem(overloadedFn)(true));
+expectType<false>(mem(overloadedFn)(false));
 
-const memoized = pMemoize(async () => 1);
-pMemoize.clear(memoized);
+mem.clear(fn);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -40,12 +40,14 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"mem": "^4.3.0",
+		"map-age-cleaner": "^0.1.3",
 		"mimic-fn": "^2.1.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
-		"tsd": "^0.7.2",
+		"delay": "^4.1.0",
+		"serialize-javascript": "^1.7.0",
+		"tsd": "^0.7.3",
 		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "p-memoize",
-	"version": "3.1.0",
+	"version": "4.0.0-0",
 	"description": "Memoize promise-returning & async functions",
 	"license": "MIT",
 	"repository": "sindresorhus/p-memoize",

--- a/readme.md
+++ b/readme.md
@@ -1,62 +1,178 @@
-# p-memoize [![Build Status](https://travis-ci.org/sindresorhus/p-memoize.svg?branch=master)](https://travis-ci.org/sindresorhus/p-memoize)
+# mem [![Build Status](https://travis-ci.org/sindresorhus/mem.svg?branch=master)](https://travis-ci.org/sindresorhus/mem)
 
-> [Memoize](https://en.wikipedia.org/wiki/Memoization) promise-returning & async functions
+> [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-Useful for speeding up consecutive function calls by caching the result of calls with identical input.
+Memory is automatically released when an item expires or the cache is cleared.
+
+By default, **only the first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, use the `cacheKey` option.
 
 
 ## Install
 
 ```
-$ npm install p-memoize
+$ npm install mem
 ```
 
 
 ## Usage
 
 ```js
-const pMemoize = require('p-memoize');
-const got = require('got');
+const mem = require('mem');
 
-const memGot = pMemoize(got, {maxAge: 1000});
+let i = 0;
+const counter = () => ++i;
+const memoized = mem(counter);
+
+memoized('foo');
+//=> 1
+
+// Cached as it's the same argument
+memoized('foo');
+//=> 1
+
+// Not cached anymore as the argument changed
+memoized('bar');
+//=> 2
+
+memoized('bar');
+//=> 2
+
+// Only the first argument is considered by default
+memoized('bar', 'foo');
+//=> 2
+```
+
+##### Works fine with promise returning functions
+
+```js
+const mem = require('mem');
+
+let i = 0;
+const counter = async () => ++i;
+const memoized = mem(counter);
 
 (async () => {
-	memGot('sindresorhus.com');
+	console.log(await memoized());
+	//=> 1
+
+	// The return value didn't increase as it's cached
+	console.log(await memoized());
+	//=> 1
+})();
+```
+
+```js
+const mem = require('mem');
+const got = require('got');
+const delay = require('delay');
+
+const memGot = mem(got, {maxAge: 1000});
+
+(async () => {
+	await memGot('sindresorhus.com');
 
 	// This call is cached
-	memGot('sindresorhus.com');
+	await memGot('sindresorhus.com');
 
-	setTimeout(() => {
-		// This call is not cached as the cache has expired
-		memGot('sindresorhus.com');
-	}, 2000);
+	await delay(2000);
+
+	// This call is not cached as the cache has expired
+	await memGot('sindresorhus.com');
 })();
 ```
 
 
 ## API
 
-### pMemoize(fn, [options])
-
-Returns a memoized version of the `fn` function.
+### mem(fn, options?)
 
 #### fn
 
 Type: `Function`
 
-Promise-returning or async function to be memoized.
+Function to be memoized.
 
 #### options
 
-Type: `Object`
+Type: `object`
 
-See the [`mem` options](https://github.com/sindresorhus/mem#options).
+##### maxAge
 
-### pMemoize.clear(memoized)
+Type: `number`\
+Default: `Infinity`
+
+Milliseconds until the cache expires.
+
+##### cacheKey
+
+Type: `Function`\
+Default: `arguments_ => arguments_[0]`\
+Example: `arguments_ => JSON.stringify(arguments_)`
+
+Determines the cache key for storing the result based on the function arguments. By default, **only the first argument is considered**.
+
+A `cacheKey` function can return any type supported by `Map` (or whatever structure you use in the `cache` option).
+
+You can have it cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
+
+```js
+const mem = require('mem');
+
+mem(function_, {cacheKey: JSON.stringify});
+```
+
+Or you can use a more full-featured serializer like [serialize-javascript](https://github.com/yahoo/serialize-javascript) to add support for `RegExp`, `Date` and so on.
+
+```js
+const mem = require('mem');
+const serializeJavascript = require('serialize-javascript');
+
+mem(function_, {cacheKey: serializeJavascript});
+```
+
+##### cache
+
+Type: `object`\
+Default: `new Map()`
+
+Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
+
+### mem.clear(fn)
 
 Clear all cached data of a memoized function.
 
-Will throw if passed a non-memoized function.
+#### fn
+
+Type: `Function`
+
+Memoized function.
+
+
+## Tips
+
+### Cache statistics
+
+If you want to know how many times your cache had a hit or a miss, you can make use of [stats-map](https://github.com/SamVerschueren/stats-map) as a replacement for the default cache.
+
+#### Example
+
+```js
+const mem = require('mem');
+const StatsMap = require('stats-map');
+const got = require('got');
+
+const cache = new StatsMap();
+const memGot = mem(got, {cache});
+
+(async () => {
+	await memGot('sindresorhus.com');
+	await memGot('sindresorhus.com');
+	await memGot('sindresorhus.com');
+
+	console.log(cache.stats);
+	//=> {hits: 2, misses: 1}
+})();
+```
 
 
 ## Related
@@ -64,8 +180,3 @@ Will throw if passed a non-memoized function.
 - [p-debounce](https://github.com/sindresorhus/p-debounce) - Debounce promise-returning & async functions
 - [p-throttle](https://github.com/sindresorhus/p-throttle) - Throttle promise-returning & async functions
 - [More…](https://github.com/sindresorhus/promise-fun)
-
-
-## License
-
-MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/test.js
+++ b/test.js
@@ -1,98 +1,98 @@
 import test from 'ava';
 import delay from 'delay';
 import serializeJavascript from 'serialize-javascript';
-import mem from '.';
+import pMemoize from '.';
 
-test('memoize', t => {
+test('memoize', async t => {
 	let i = 0;
-	const fixture = () => i++;
-	const memoized = mem(fixture);
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	t.is(memoized(undefined), 0);
-	t.is(memoized(undefined), 0);
-	t.is(memoized('foo'), 1);
-	t.is(memoized('foo'), 1);
-	t.is(memoized('foo'), 1);
-	t.is(memoized('foo', 'bar'), 1);
-	t.is(memoized('foo', 'bar'), 1);
-	t.is(memoized('foo', 'bar'), 1);
-	t.is(memoized(1), 2);
-	t.is(memoized(1), 2);
-	t.is(memoized(null), 3);
-	t.is(memoized(null), 3);
-	t.is(memoized(fixture), 4);
-	t.is(memoized(fixture), 4);
-	t.is(memoized(true), 5);
-	t.is(memoized(true), 5);
+	const fixture = async () => i++;
+	const memoized = pMemoize(fixture);
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	t.is(await memoized(undefined), 0);
+	t.is(await memoized(undefined), 0);
+	t.is(await memoized('foo'), 1);
+	t.is(await memoized('foo'), 1);
+	t.is(await memoized('foo'), 1);
+	t.is(await memoized('foo', 'bar'), 1);
+	t.is(await memoized('foo', 'bar'), 1);
+	t.is(await memoized('foo', 'bar'), 1);
+	t.is(await memoized(1), 2);
+	t.is(await memoized(1), 2);
+	t.is(await memoized(null), 3);
+	t.is(await memoized(null), 3);
+	t.is(await memoized(fixture), 4);
+	t.is(await memoized(fixture), 4);
+	t.is(await memoized(true), 5);
+	t.is(await memoized(true), 5);
 
 	// Ensure that functions are stored by reference and not by "value" (e.g. their `.toString()` representation)
-	t.is(memoized(() => i++), 6);
-	t.is(memoized(() => i++), 7);
+	t.is(await memoized(() => i++), 6);
+	t.is(await memoized(() => i++), 7);
 });
 
-test('cacheKey option', t => {
+test('cacheKey option', async t => {
 	let i = 0;
-	const fixture = () => i++;
-	const memoized = mem(fixture, {cacheKey: ([firstArgument]) => String(firstArgument)});
-	t.is(memoized(1), 0);
-	t.is(memoized(1), 0);
-	t.is(memoized('1'), 0);
-	t.is(memoized('2'), 1);
-	t.is(memoized(2), 1);
+	const fixture = async () => i++;
+	const memoized = pMemoize(fixture, {cacheKey: ([firstArgument]) => String(firstArgument)});
+	t.is(await memoized(1), 0);
+	t.is(await memoized(1), 0);
+	t.is(await memoized('1'), 0);
+	t.is(await memoized('2'), 1);
+	t.is(await memoized(2), 1);
 });
 
-test('memoize with multiple non-primitive arguments', t => {
+test('memoize with multiple non-primitive arguments', async t => {
 	let i = 0;
-	const memoized = mem(() => i++, {cacheKey: JSON.stringify});
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	t.is(memoized({foo: true}, {bar: false}), 1);
-	t.is(memoized({foo: true}, {bar: false}), 1);
-	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
-	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
+	const memoized = pMemoize(async () => i++, {cacheKey: JSON.stringify});
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	t.is(await memoized({foo: true}, {bar: false}), 1);
+	t.is(await memoized({foo: true}, {bar: false}), 1);
+	t.is(await memoized({foo: true}, {bar: false}, {baz: true}), 2);
+	t.is(await memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
-test('memoize with regexp arguments', t => {
+test('memoize with regexp arguments', async t => {
 	let i = 0;
-	const memoized = mem(() => i++, {cacheKey: serializeJavascript});
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	t.is(memoized(/Sindre Sorhus/), 1);
-	t.is(memoized(/Sindre Sorhus/), 1);
-	t.is(memoized(/Elvin Peng/), 2);
-	t.is(memoized(/Elvin Peng/), 2);
+	const memoized = pMemoize(async () => i++, {cacheKey: serializeJavascript});
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	t.is(await memoized(/Sindre Sorhus/), 1);
+	t.is(await memoized(/Sindre Sorhus/), 1);
+	t.is(await memoized(/Elvin Peng/), 2);
+	t.is(await memoized(/Elvin Peng/), 2);
 });
 
-test('memoize with Symbol arguments', t => {
+test('memoize with Symbol arguments', async t => {
 	let i = 0;
 	const argument1 = Symbol('fixture1');
 	const argument2 = Symbol('fixture2');
-	const memoized = mem(() => i++);
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	t.is(memoized(argument1), 1);
-	t.is(memoized(argument1), 1);
-	t.is(memoized(argument2), 2);
-	t.is(memoized(argument2), 2);
+	const memoized = pMemoize(async () => i++);
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	t.is(await memoized(argument1), 1);
+	t.is(await memoized(argument1), 1);
+	t.is(await memoized(argument2), 2);
+	t.is(await memoized(argument2), 2);
 });
 
 test('maxAge option', async t => {
 	let i = 0;
-	const fixture = () => i++;
-	const memoized = mem(fixture, {maxAge: 100});
-	t.is(memoized(1), 0);
-	t.is(memoized(1), 0);
+	const fixture = async () => i++;
+	const memoized = pMemoize(fixture, {maxAge: 100});
+	t.is(await memoized(1), 0);
+	t.is(await memoized(1), 0);
 	await delay(50);
-	t.is(memoized(1), 0);
+	t.is(await memoized(1), 0);
 	await delay(200);
-	t.is(memoized(1), 1);
+	t.is(await memoized(1), 1);
 });
 
 test('maxAge option deletes old items', async t => {
 	let i = 0;
-	const fixture = () => i++;
+	const fixture = async () => i++;
 	const cache = new Map();
 	const deleted = [];
 	const remove = cache.delete.bind(cache);
@@ -101,22 +101,23 @@ test('maxAge option deletes old items', async t => {
 		return remove(item);
 	};
 
-	const memoized = mem(fixture, {maxAge: 100, cache});
-	t.is(memoized(1), 0);
-	t.is(memoized(1), 0);
+	const memoized = pMemoize(fixture, {maxAge: 100, cache});
+	t.is(await memoized(1), 0);
+	t.is(await memoized(1), 0);
 	t.is(cache.has(1), true);
 	await delay(50);
-	t.is(memoized(1), 0);
+	t.is(await memoized(1), 0);
 	t.is(deleted.length, 0);
 	await delay(200);
-	t.is(memoized(1), 1);
+	t.is(await memoized(1), 1);
 	t.is(deleted.length, 1);
 	t.is(deleted[0], 1);
 });
 
 test('maxAge items are deleted even if function throws', async t => {
 	let i = 0;
-	const fixture = () => {
+	const fixture = async () => {
+		console.log(22222)
 		if (i === 1) {
 			throw new Error('failure');
 		}
@@ -125,57 +126,57 @@ test('maxAge items are deleted even if function throws', async t => {
 	};
 
 	const cache = new Map();
-	const memoized = mem(fixture, {maxAge: 100, cache});
-	t.is(memoized(1), 0);
-	t.is(memoized(1), 0);
+	const memoized = pMemoize(fixture, {maxAge: 100, cache});
+	t.is(await memoized(1), 0);
+	t.is(await memoized(1), 0);
 	t.is(cache.size, 1);
 	await delay(50);
-	t.is(memoized(1), 0);
+	t.is(await memoized(1), 0);
 	await delay(200);
-	t.throws(() => memoized(1), 'failure');
+	await t.throwsAsync(async () => memoized(1), 'failure');
 	t.is(cache.size, 0);
 });
 
-test('cache option', t => {
+test('cache option', async t => {
 	let i = 0;
 	const fixture = () => i++;
-	const memoized = mem(fixture, {
+	const memoized = pMemoize(fixture, {
 		cache: new WeakMap(),
 		cacheKey: ([firstArgument]) => firstArgument
 	});
 	const foo = {};
 	const bar = {};
-	t.is(memoized(foo), 0);
-	t.is(memoized(foo), 0);
-	t.is(memoized(bar), 1);
-	t.is(memoized(bar), 1);
+	t.is(await memoized(foo), 0);
+	t.is(await memoized(foo), 0);
+	t.is(await memoized(bar), 1);
+	t.is(await memoized(bar), 1);
 });
 
 test('promise support', async t => {
 	let i = 0;
-	const memoized = mem(async () => i++);
+	const memoized = pMemoize(async () => i++);
 	t.is(await memoized(), 0);
 	t.is(await memoized(), 0);
 	t.is(await memoized(10), 1);
 });
 
 test('preserves the original function name', t => {
-	t.is(mem(function foo() {}).name, 'foo'); // eslint-disable-line func-names
+	t.is(pMemoize(async function foo() {}).name, 'foo'); // eslint-disable-line func-names
 });
 
-test('.clear()', t => {
+test('.clear()', async t => {
 	let i = 0;
-	const fixture = () => i++;
-	const memoized = mem(fixture);
-	t.is(memoized(), 0);
-	t.is(memoized(), 0);
-	mem.clear(memoized);
-	t.is(memoized(), 1);
-	t.is(memoized(), 1);
+	const fixture = async () => i++;
+	const memoized = pMemoize(fixture);
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
+	pMemoize.clear(memoized);
+	t.is(await memoized(), 1);
+	t.is(await memoized(), 1);
 });
 
-test('prototype support', t => {
-	const fixture = function () {
+test('prototype support', async t => {
+	const fixture = async function () {
 		return this.i++;
 	};
 
@@ -183,17 +184,11 @@ test('prototype support', t => {
 		this.i = 0;
 	};
 
-	Unicorn.prototype.foo = mem(fixture);
+	Unicorn.prototype.foo = pMemoize(fixture);
 
 	const unicorn = new Unicorn();
 
-	t.is(unicorn.foo(), 0);
-	t.is(unicorn.foo(), 0);
-	t.is(unicorn.foo(), 0);
-});
-
-test('mem.clear() throws when called with a plain function', t => {
-	t.throws(() => {
-		mem.clear(() => {});
-	}, 'Can\'t clear a function that was not memoized!');
+	t.is(await unicorn.foo(), 0);
+	t.is(await unicorn.foo(), 0);
+	t.is(await unicorn.foo(), 0);
 });

--- a/test.js
+++ b/test.js
@@ -1,55 +1,199 @@
 import test from 'ava';
-import pMemoize from '.';
+import delay from 'delay';
+import serializeJavascript from 'serialize-javascript';
+import mem from '.';
 
-test('main', async t => {
+test('memoize', t => {
 	let i = 0;
-	const memoized = pMemoize(async () => i++);
+	const fixture = () => i++;
+	const memoized = mem(fixture);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(undefined), 0);
+	t.is(memoized(undefined), 0);
+	t.is(memoized('foo'), 1);
+	t.is(memoized('foo'), 1);
+	t.is(memoized('foo'), 1);
+	t.is(memoized('foo', 'bar'), 1);
+	t.is(memoized('foo', 'bar'), 1);
+	t.is(memoized('foo', 'bar'), 1);
+	t.is(memoized(1), 2);
+	t.is(memoized(1), 2);
+	t.is(memoized(null), 3);
+	t.is(memoized(null), 3);
+	t.is(memoized(fixture), 4);
+	t.is(memoized(fixture), 4);
+	t.is(memoized(true), 5);
+	t.is(memoized(true), 5);
+
+	// Ensure that functions are stored by reference and not by "value" (e.g. their `.toString()` representation)
+	t.is(memoized(() => i++), 6);
+	t.is(memoized(() => i++), 7);
+});
+
+test('cacheKey option', t => {
+	let i = 0;
+	const fixture = () => i++;
+	const memoized = mem(fixture, {cacheKey: ([firstArgument]) => String(firstArgument)});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	t.is(memoized('1'), 0);
+	t.is(memoized('2'), 1);
+	t.is(memoized(2), 1);
+});
+
+test('memoize with multiple non-primitive arguments', t => {
+	let i = 0;
+	const memoized = mem(() => i++, {cacheKey: JSON.stringify});
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized({foo: true}, {bar: false}), 1);
+	t.is(memoized({foo: true}, {bar: false}), 1);
+	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
+	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
+});
+
+test('memoize with regexp arguments', t => {
+	let i = 0;
+	const memoized = mem(() => i++, {cacheKey: serializeJavascript});
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Elvin Peng/), 2);
+	t.is(memoized(/Elvin Peng/), 2);
+});
+
+test('memoize with Symbol arguments', t => {
+	let i = 0;
+	const argument1 = Symbol('fixture1');
+	const argument2 = Symbol('fixture2');
+	const memoized = mem(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(argument1), 1);
+	t.is(memoized(argument1), 1);
+	t.is(memoized(argument2), 2);
+	t.is(memoized(argument2), 2);
+});
+
+test('maxAge option', async t => {
+	let i = 0;
+	const fixture = () => i++;
+	const memoized = mem(fixture, {maxAge: 100});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	await delay(50);
+	t.is(memoized(1), 0);
+	await delay(200);
+	t.is(memoized(1), 1);
+});
+
+test('maxAge option deletes old items', async t => {
+	let i = 0;
+	const fixture = () => i++;
+	const cache = new Map();
+	const deleted = [];
+	const remove = cache.delete.bind(cache);
+	cache.delete = item => {
+		deleted.push(item);
+		return remove(item);
+	};
+
+	const memoized = mem(fixture, {maxAge: 100, cache});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	t.is(cache.has(1), true);
+	await delay(50);
+	t.is(memoized(1), 0);
+	t.is(deleted.length, 0);
+	await delay(200);
+	t.is(memoized(1), 1);
+	t.is(deleted.length, 1);
+	t.is(deleted[0], 1);
+});
+
+test('maxAge items are deleted even if function throws', async t => {
+	let i = 0;
+	const fixture = () => {
+		if (i === 1) {
+			throw new Error('failure');
+		}
+
+		return i++;
+	};
+
+	const cache = new Map();
+	const memoized = mem(fixture, {maxAge: 100, cache});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	t.is(cache.size, 1);
+	await delay(50);
+	t.is(memoized(1), 0);
+	await delay(200);
+	t.throws(() => memoized(1), 'failure');
+	t.is(cache.size, 0);
+});
+
+test('cache option', t => {
+	let i = 0;
+	const fixture = () => i++;
+	const memoized = mem(fixture, {
+		cache: new WeakMap(),
+		cacheKey: ([firstArgument]) => firstArgument
+	});
+	const foo = {};
+	const bar = {};
+	t.is(memoized(foo), 0);
+	t.is(memoized(foo), 0);
+	t.is(memoized(bar), 1);
+	t.is(memoized(bar), 1);
+});
+
+test('promise support', async t => {
+	let i = 0;
+	const memoized = mem(async () => i++);
 	t.is(await memoized(), 0);
 	t.is(await memoized(), 0);
 	t.is(await memoized(10), 1);
 });
 
-test('does not memoize rejected promise', async t => {
-	let i = 0;
-
-	const memoized = pMemoize(async () => {
-		i++;
-
-		if (i === 2) {
-			throw new Error('fixture');
-		}
-
-		return i;
-	});
-
-	t.is(await memoized(), 1);
-	t.is(await memoized(), 1);
-
-	await t.throwsAsync(memoized(10), 'fixture');
-	await t.notThrowsAsync(memoized(10));
-
-	t.is(await memoized(10), 3);
-	t.is(await memoized(10), 3);
-	t.is(await memoized(100), 4);
-});
-
 test('preserves the original function name', t => {
-	t.is(pMemoize(async function foo() {}).name, 'foo'); // eslint-disable-line func-names
+	t.is(mem(function foo() {}).name, 'foo'); // eslint-disable-line func-names
 });
 
-test('pMemoize.clear()', t => {
+test('.clear()', t => {
 	let i = 0;
 	const fixture = () => i++;
-	const memoized = pMemoize(fixture);
+	const memoized = mem(fixture);
 	t.is(memoized(), 0);
 	t.is(memoized(), 0);
-	pMemoize.clear(memoized);
+	mem.clear(memoized);
 	t.is(memoized(), 1);
 	t.is(memoized(), 1);
 });
 
-test('pMemoize.clear() throws when called with a plain function', t => {
+test('prototype support', t => {
+	const fixture = function () {
+		return this.i++;
+	};
+
+	const Unicorn = function () {
+		this.i = 0;
+	};
+
+	Unicorn.prototype.foo = mem(fixture);
+
+	const unicorn = new Unicorn();
+
+	t.is(unicorn.foo(), 0);
+	t.is(unicorn.foo(), 0);
+	t.is(unicorn.foo(), 0);
+});
+
+test('mem.clear() throws when called with a plain function', t => {
 	t.throws(() => {
-		pMemoize.clear(() => {});
+		mem.clear(() => {});
 	}, 'Can\'t clear a function that was not memoized!');
 });

--- a/test.js
+++ b/test.js
@@ -117,7 +117,6 @@ test('maxAge option deletes old items', async t => {
 test('maxAge items are deleted even if function throws', async t => {
 	let i = 0;
 	const fixture = async () => {
-		console.log(22222)
 		if (i === 1) {
 			throw new Error('failure');
 		}


### PR DESCRIPTION
Enables and closes #3 

- [ ] Fix broken test related to https://github.com/SamVerschueren/map-age-cleaner
  AVA seems to fail only on the test `maxAge items are deleted even if function throws`
- [ ] Fix async Map types
- [ ] Add async-specific tests, using https://github.com/lukechilds/keyv for example

### Docs

- [ ] Update all mentions of `mem` to `p-memoize` in docs
- [ ] Explain difference with `mem` also on `mem`'s repo