### PR TITLE
Add `cachePromiseRejection` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare const pMemoize: {
 	[Memoize](https://en.wikipedia.org/wiki/Memoization) promise-returning & async functions.
 
 	@param fn - Promise-returning or async function to be memoized.
-	@param pMemoizeOptions - See the [`p-memoize` options](https://github.com/sindresorhus/p-memoize#options).
+	@param options - See the [`p-memoize` options](https://github.com/sindresorhus/p-memoize#options).
 	@returns A memoized version of the `input` function.
 
 	@example
@@ -44,7 +44,7 @@ declare const pMemoize: {
 	*/
 	<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
 		fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-		pMemoizeOptions?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
+		options?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
 	): (...arguments: ArgumentsType) => Promise<ReturnType>;
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,14 @@ declare namespace pMemoize {
 		ArgumentsType extends unknown[],
 		CacheKeyType,
 		ReturnType
-	> = MemOptions<ArgumentsType, CacheKeyType, ReturnType>;
+	> = MemOptions<ArgumentsType, CacheKeyType, ReturnType> & {
+		/**
+		Cache rejected promises.
+
+		@default false
+		*/
+		readonly cachePromiseRejection?: boolean;
+	};
 }
 declare const pMemoize: {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare const pMemoize: {
 	[Memoize](https://en.wikipedia.org/wiki/Memoization) promise-returning & async functions.
 
 	@param fn - Promise-returning or async function to be memoized.
-	@param memoizeOptions - See the [`mem` options](https://github.com/sindresorhus/mem#options).
+	@param pMemoizeOptions - See the [`p-memoize` options](https://github.com/sindresorhus/p-memoize#options).
 	@returns A memoized version of the `input` function.
 
 	@example
@@ -44,7 +44,7 @@ declare const pMemoize: {
 	*/
 	<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
 		fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-		memoizeOptions?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
+		pMemoizeOptions?: pMemoize.Options<ArgumentsType, CacheKeyType, ReturnType>
 	): (...arguments: ArgumentsType) => Promise<ReturnType>;
 
 	/**

--- a/index.js
+++ b/index.js
@@ -4,11 +4,23 @@ const mimicFn = require('mimic-fn');
 
 const memoizedFunctions = new WeakMap();
 
-const pMemoize = (fn, options) => {
-	const memoized = mem(fn, options);
+const pMemoize = (fn, options = {}) => {
+	const cache = options.cache || new Map();
+	const cacheKey = options.cacheKey || (([firstArgument]) => firstArgument);
+
+	const memoized = mem(fn, {
+		...options,
+		cache
+	});
 
 	const memoizedAdapter = function (...arguments_) {
-		return memoized.apply(this, arguments_);
+		const cacheItem = memoized.apply(this, arguments_);
+
+		if (options.cachePromiseRejection !== true && cacheItem && cacheItem.catch) {
+			cacheItem.catch(() => cache.delete(cacheKey(arguments_)));
+		}
+
+		return cacheItem;
 	};
 
 	mimicFn(memoizedAdapter, fn);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ const pMemoize = (fn, options = {}) => {
 		const cacheItem = memoized.apply(this, arguments_);
 
 		if (options.cachePromiseRejection !== true && cacheItem && cacheItem.catch) {
-			cacheItem.catch(() => cache.delete(cacheKey(arguments_)));
+			cacheItem.catch(() => {
+				cache.delete(cacheKey(arguments_));
+			});
 		}
 
 		return cacheItem;

--- a/index.js
+++ b/index.js
@@ -4,19 +4,20 @@ const mimicFn = require('mimic-fn');
 
 const memoizedFunctions = new WeakMap();
 
-const pMemoize = (fn, options = {}) => {
+const pMemoize = (fn, {cachePromiseRejection = false, ...options} = {}) => {
 	const cache = options.cache || new Map();
 	const cacheKey = options.cacheKey || (([firstArgument]) => firstArgument);
 
 	const memoized = mem(fn, {
 		...options,
-		cache
+		cache,
+		cacheKey
 	});
 
 	const memoizedAdapter = function (...arguments_) {
 		const cacheItem = memoized.apply(this, arguments_);
 
-		if (options.cachePromiseRejection !== true && cacheItem && cacheItem.catch) {
+		if (!cachePromiseRejection && cacheItem && cacheItem.catch) {
 			cacheItem.catch(() => {
 				cache.delete(cacheKey(arguments_));
 			});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,7 +6,7 @@ expectType<(name: string) => Promise<string>>(
 );
 expectType<() => Promise<number>>(pMemoize(async () => 1));
 
-pMemoize(async () => 1, {maxAge: 1});
+pMemoize(async () => 1, {maxAge: 1, cachePromiseRejection: true});
 
 const memoized = pMemoize(async () => 1);
 pMemoize.clear(memoized);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"mem": "^4.3.0",
+		"mem": "^6.0.1",
 		"mimic-fn": "^2.1.0"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ See the [`mem` options](https://github.com/sindresorhus/mem#options) in addition
 Type: `boolean`\
 Default: `false`
 
-Keep rejected promises in the cache.
+Cache rejected promises.
 
 ### pMemoize.clear(memoized)
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,12 @@ Type: `object`
 
 See the [`mem` options](https://github.com/sindresorhus/mem#options).
 
-Also supports `cachePromiseRejection` which was removed in mem@6.0.0. Default is `false`.
+##### cachePromiseRejection
+
+Type: `boolean`
+Default: `false`
+
+Set to `true` to keep rejected promises in the cache.
 
 ### pMemoize.clear(memoized)
 

--- a/readme.md
+++ b/readme.md
@@ -47,14 +47,14 @@ Promise-returning or async function to be memoized.
 
 Type: `object`
 
-See the [`mem` options](https://github.com/sindresorhus/mem#options).
+See the [`mem` options](https://github.com/sindresorhus/mem#options) in addition to the below option.
 
 ##### cachePromiseRejection
 
-Type: `boolean`
+Type: `boolean`\
 Default: `false`
 
-Set to `true` to keep rejected promises in the cache.
+Keep rejected promises in the cache.
 
 ### pMemoize.clear(memoized)
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ Type: `Object`
 
 See the [`mem` options](https://github.com/sindresorhus/mem#options).
 
+Also supports `cachePromiseRejection` which was removed in mem@6.0.0. Default is `false`.
+
 ### pMemoize.clear(memoized)
 
 Clear all cached data of a memoized function.

--- a/test.js
+++ b/test.js
@@ -33,6 +33,30 @@ test('does not memoize rejected promise', async t => {
 	t.is(await memoized(100), 4);
 });
 
+test('can memoize rejected promise', async t => {
+	let i = 0;
+
+	const memoized = pMemoize(async () => {
+		i++;
+
+		if (i === 2) {
+			throw new Error('fixture');
+		}
+
+		return i;
+	}, {
+		cachePromiseRejection: true
+	});
+
+	t.is(await memoized(), 1);
+	t.is(await memoized(), 1);
+
+	await t.throwsAsync(memoized(10), 'fixture');
+	await t.throwsAsync(memoized(10), 'fixture');
+
+	t.is(await memoized(100), 3);
+});
+
 test('preserves the original function name', t => {
 	t.is(pMemoize(async function foo() {}).name, 'foo'); // eslint-disable-line func-names
 });


### PR DESCRIPTION
Hello, here is my attempt at adding the `cachePromiseRejection` option removed from mem.

I think the default should be false because rejected promises are like exceptions and an exception thrown from a function memoized with mem doesn't cache anything.

I used the same name that was used in mem, but it sounds awkward to me and wonder if `cacheRejectedPromises` might be more natural.

Fixes #11 