### PR TITLE
Add mem's cache key explanation to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 Useful for speeding up consecutive function calls by caching the result of calls with identical input.
 
+By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
+
 ## Install
 
 ```


### PR DESCRIPTION
The https://github.com/sindresorhus/mem package has this explanation prominently displayed. I didn't realize it until I dug into the options object, and figured it would be useful to bring this to the top like mem does.