### PR TITLE
Document difference between this module and `mem`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Useful for speeding up consecutive function calls by caching the result of calls
 
 By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
 
-This package is similar to [mem](https://github.com/sindresorhus/mem), but does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
+This package is similar to [mem](https://github.com/sindresorhus/mem) but with enhancements specific to async operations; in particular, it does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Useful for speeding up consecutive function calls by caching the result of calls
 
 By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
 
-This package is similar to [mem](https://github.com/sindresorhus/mem), but the cached result will be evicted from the cache immediately if the promise is rejected (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
+This package is similar to [mem](https://github.com/sindresorhus/mem), but does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ Useful for speeding up consecutive function calls by caching the result of calls
 
 By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
 
+This package is similar to [mem](https://github.com/sindresorhus/mem), but the cached result will be evicted from the cache immediately if the promise is rejected (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
+
 ## Install
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Useful for speeding up consecutive function calls by caching the result of calls
 
 By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
 
-This package is similar to [mem](https://github.com/sindresorhus/mem) but with enhancements specific to async operations; in particular, it does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
+This package is similar to [mem](https://github.com/sindresorhus/mem) but with async-specific enhancements; in particular, it does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
 
 ## Install
 


### PR DESCRIPTION
The package `mem` and `p-memoize` looks so similar, so I wonder what is the difference (i.e. why two packages? why I shouldn't we just use mem?) so I looked into the implementation. This PR documents the difference.