### PR TITLE
Replace incorrect info about Primitives with `strict equality` mention

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Useful for speeding up consecutive function calls by caching the result of calls with identical input.
 
-By default, **only the memoized function's first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
+By default, **only the memoized function's first argument is considered** via strict equality comparison. If you need to cache multiple arguments or cache `object`s *by value*, have a look at [options](#options) below.
 
 ## Install
 


### PR DESCRIPTION
`mem` does not _only work with primitives_; it works with any value, it's just that `fn({n: 1});fn({n: 1});` might not match the user’s expectations.