### PR TITLE
Fix `maxAge` start on Promise settlement

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
 		"bluebird"
 	],
 	"dependencies": {
+		"map-age-cleaner": "^0.1.3",
 		"mem": "^6.0.1",
 		"mimic-fn": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
+		"delay": "^5.0.0",
 		"tsd": "^0.11.0",
 		"xo": "^0.26.1"
 	}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 	],
 	"dependencies": {
 		"map-age-cleaner": "^0.1.3",
-		"mem": "^6.0.1",
 		"mimic-fn": "^3.0.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -64,13 +64,21 @@ test('preserves the original function name', t => {
 
 test('pMemoize.clear()', async t => {
 	let i = 0;
-	const fixture = () => i++;
+	const fixture = async () => i++;
 	const memoized = pMemoize(fixture);
 	t.is(await memoized(), 0);
 	t.is(await memoized(), 0);
 	pMemoize.clear(memoized);
 	t.is(await memoized(), 1);
 	t.is(await memoized(), 1);
+});
+
+test('always returns async function', async t => {
+	let i = 0;
+	const fixture = () => i++;
+	const memoized = pMemoize(fixture);
+	t.is(await memoized(), 0);
+	t.is(await memoized(), 0);
 });
 
 test('pMemoize.clear() throws when called with a plain function', t => {


### PR DESCRIPTION
This is PR base on issue https://github.com/sindresorhus/p-memoize/issues/22.

I've tried to keep the dependency on mem at firt, but I've not found any solution where it would make sense. After I added the maxAge map here to the `p-memoize` there wasn't basically any reason to keep mem in here. Maybe just for the `clear` function but in my opinien it is cleaner to have here `cacheStore` then to have dependency just for that purpose.

The only change is in the maxAge, all other behaviour should be unchanged.
Alltho the code would be cleaner if we would create from every function -> async function but I would rather have a bit more complicated code and keep the behaviour.

Let me know what you think or if you see any other nice, cleaner solutions.

---

Fixes #22