### PR TITLE
Fix TypeScript type of optional custom cache

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ setTimeout(() => {
 */
 export default function pMemoize<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
 	fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-	options?: Options<ArgumentsType, CacheKeyType, ReturnType>
+	options?: Options<ArgumentsType, CacheKeyType, <PromiseLike<ReturnType>>
 ): (...arguments: ArgumentsType) => Promise<ReturnType>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ setTimeout(() => {
 */
 export default function pMemoize<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
 	fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-	options?: Options<ArgumentsType, CacheKeyType, <PromiseLike<ReturnType>>
+	options?: Options<ArgumentsType, CacheKeyType, PromiseLike<ReturnType>>
 ): (...arguments: ArgumentsType) => Promise<ReturnType>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,11 @@ export interface CacheStorage<KeyType, ValueType> {
 	clear?: () => void; // eslint-disable-line @typescript-eslint/member-ordering
 }
 
+export interface CacheItem<ReturnType> {
+	data: PromiseLike<ReturnType>;
+	maxAge: number;
+}
+
 export type Options<
 	ArgumentsType extends unknown[],
 	CacheKeyType,
@@ -47,7 +52,7 @@ export type Options<
 
 	See the [caching strategy](https://github.com/sindresorhus/mem#caching-strategy) section in the `mem` package for more information.
 	*/
-	readonly cache?: CacheStorage<CacheKeyType, {data: ReturnType; maxAge: number}>;
+	readonly cache?: CacheStorage<CacheKeyType, CacheItem<ReturnType>>;
 };
 
 /**
@@ -77,7 +82,7 @@ setTimeout(() => {
 */
 export default function pMemoize<ArgumentsType extends unknown[], ReturnType, CacheKeyType>(
 	fn: (...arguments: ArgumentsType) => PromiseLike<ReturnType>,
-	options?: Options<ArgumentsType, CacheKeyType, PromiseLike<ReturnType>>
+	options?: Options<ArgumentsType, CacheKeyType, ReturnType>
 ): (...arguments: ArgumentsType) => Promise<ReturnType>;
 
 /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,10 +1,14 @@
 import {expectType} from 'tsd';
-import pMemoize, {pMemoizeClear} from './index.js';
+import pMemoize, {CacheItem, pMemoizeClear} from './index.js';
 
 expectType<(name: string) => Promise<string>>(
 	pMemoize(async (name: string) => `Hello ${name}!`),
 );
 expectType<() => Promise<number>>(pMemoize(async () => 1));
+
+expectType<() => Promise<number>>(pMemoize(async () => 1, {
+	cache: new Map<string, CacheItem<number>>()
+}));
 
 pMemoize(async () => 1, {maxAge: 1, cachePromiseRejection: true});
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ expectType<(name: string) => Promise<string>>(
 expectType<() => Promise<number>>(pMemoize(async () => 1));
 
 expectType<() => Promise<number>>(pMemoize(async () => 1, {
-	cache: new Map<string, CacheItem<number>>()
+	cache: new Map<string, CacheItem<number>>(),
 }));
 
 pMemoize(async () => 1, {maxAge: 1, cachePromiseRejection: true});


### PR DESCRIPTION
p-memoize takes a function that returns promised values, and may optionally
take a custom cache to store these promised values. However, the type
of the custom cache was incorrectly "ReturnType" instead of "PromiseLike<ReturnType>",
meaning if you create a correctly typed cache that stores promised values, it will
not be possible to pass it to p-memoize without any-casting it. Instead, p-memoize
expects a cache of resolved values, which is not what it actually is.