### PR TITLE
Only use internal promise cache if a value already exists in `cache`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -104,11 +104,11 @@ export default function pMemoize<
 	const memoized = async function (this: any, ...arguments_: Parameters<FunctionToMemoize>): Promise<AsyncReturnType<FunctionToMemoize>> {
 		const key = cacheKey ? cacheKey(arguments_) : arguments_[0] as CacheKeyType;
 
-		if (promiseCache.has(key)) {
-			return promiseCache.get(key)!;
-		}
-
 		if (await cache.has(key)) {
+			if (promiseCache.has(key)) {
+				return promiseCache.get(key)!;
+			}
+
 			return (await cache.get(key))!;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ await memoizedGot('https://sindresorhus.com');
 
 Similar to the [caching strategy for `mem`](https://github.com/sindresorhus/mem#options) with the following exceptions:
 
-- Promises returned from a memoized function will be cached internally and take priority over `cache`. The promise cache does not persist outside of the current instance and properties assigned to a returned promise will not be kept. All cached promises can be cleared with [`pMemoizeClear()`](#pmemoizeclearfn).
+- Promises returned from a memoized function will be cached internally and take priority over `cache` if a value exists in both caches. The promise cache does not persist outside of the current instance and properties assigned to a returned promise will not be kept. All cached promises can be cleared with [`pMemoizeClear()`](#pmemoizeclearfn).
 - `.get()` and `.has()` methods on `cache` can return a promise instead of returning a value immediately.
 - Instead of `.set()` being provided an object with the properties `value` and `maxAge`, it will only be provided `value` as the first argument. If you want to implement time-based expiry, consider [doing so in `cache`](#time-based-cache-expiration).
 

--- a/test.ts
+++ b/test.ts
@@ -122,6 +122,22 @@ test('cache option', async t => {
 	t.is(await memoized(bar), 1);
 });
 
+test('internal promise cache is only used if a value already exists in cache', async t => {
+	let index = 0;
+	const fixture = async (..._arguments: any) => index++;
+	const cache = new Map();
+	const memoized = pMemoize(fixture, {
+		cache,
+		cacheKey: <ReturnValue>([firstArgument]: [ReturnValue]): ReturnValue => firstArgument,
+	});
+	const foo = {};
+	t.is(await memoized(foo), 0);
+	t.is(await memoized(foo), 0);
+	cache.delete(foo);
+	t.is(await memoized(foo), 1);
+	t.is(await memoized(foo), 1);
+});
+
 test('preserves the original function name', t => {
 	t.is(pMemoize(async function foo() {}).name, 'foo'); // eslint-disable-line func-names, @typescript-eslint/no-empty-function
 });


### PR DESCRIPTION
Fixes #31