### PR TITLE
Fix the memory leak in `promiseCache`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,6 +128,8 @@ export default function pMemoize<
 			}
 
 			throw error as Error;
+		} finally {
+			promiseCache.delete(key);
 		}
 	} as FunctionToMemoize;
 


### PR DESCRIPTION
This is a fix for the issue discussed in #31, currently the `promiseCache` keeps getting larger, the keys are never removed unless `pMemoizeClear` is explicitly used.

In this fix, we delete the key from `promiseCache` when the promise is [settled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally) (Resolved or rejected).

Also I would like your opinion about `promiseCacheStore` if it's still needed after this change?
I guess we can safely remove it.

Also if this gets merged we can solve concurrent invocations #43 by first checking the `promiseCache` and returning the promise before checking `cache`, for example:

```ts
if (promiseCache.has(key)) {
  return promiseCache.get(key)!;
}

if (cache.has(key)) {
  return cache.get(key) as AsyncReturnType<FunctionToMemoize>;
}
```