### PR TITLE
Allow `.set()` to be async, only cache promises until they resolve, synchronously cache pending promises and remove `cachePromiseRejection`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,30 +93,34 @@ export default function pMemoize<
 	// `Promise<AsyncReturnType<FunctionToMemoize>>` is used instead of `ReturnType<FunctionToMemoize>` because promise properties are not kept
 	const promiseCache = new Map<CacheKeyType, Promise<AsyncReturnType<FunctionToMemoize>>>();
 
-	const memoized = async function (this: any, ...arguments_: Parameters<FunctionToMemoize>): Promise<AsyncReturnType<FunctionToMemoize>> {
+	const memoized = function (this: any, ...arguments_: Parameters<FunctionToMemoize>): Promise<AsyncReturnType<FunctionToMemoize>> {
 		const key = cacheKey ? cacheKey(arguments_) : arguments_[0] as CacheKeyType;
 
 		if (promiseCache.has(key)) {
 			return promiseCache.get(key)!;
 		}
 
-		if (await cache.has(key)) {
-			return (await cache.get(key))!;
-		}
+		const promise = (async () => {
+			try {
+				if (await cache.has(key)) {
+					return (await cache.get(key))!;
+				}
 
-		const promise = fn.apply(this, arguments_) as Promise<AsyncReturnType<FunctionToMemoize>>;
+				const promise = fn.apply(this, arguments_) as Promise<AsyncReturnType<FunctionToMemoize>>;
+
+				const result = await promise;
+
+				await cache.set(key, result);
+
+				return result;
+			} finally {
+				promiseCache.delete(key);
+			}
+		})();
 
 		promiseCache.set(key, promise);
 
-		try {
-			const result = await promise;
-
-			await cache.set(key, result);
-
-			return result;
-		} finally {
-			promiseCache.delete(key);
-		}
+		return promise;
 	} as FunctionToMemoize;
 
 	mimicFn(memoized, fn, {

--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,7 @@ export default function pMemoize<
 	// `Promise<AsyncReturnType<FunctionToMemoize>>` is used instead of `ReturnType<FunctionToMemoize>` because promise properties are not kept
 	const promiseCache = new Map<CacheKeyType, Promise<AsyncReturnType<FunctionToMemoize>>>();
 
-	const memoized = function (this: any, ...arguments_: Parameters<FunctionToMemoize>): Promise<AsyncReturnType<FunctionToMemoize>> {
+	const memoized = function (this: any, ...arguments_: Parameters<FunctionToMemoize>): Promise<AsyncReturnType<FunctionToMemoize>> { // eslint-disable-line @typescript-eslint/promise-function-async
 		const key = cacheKey ? cacheKey(arguments_) : arguments_[0] as CacheKeyType;
 
 		if (promiseCache.has(key)) {

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,6 @@ import type {AsyncReturnType} from 'type-fest';
 export type AnyAsyncFunction = (...arguments_: readonly any[]) => Promise<unknown | void>;
 
 const cacheStore = new WeakMap<AnyAsyncFunction, CacheStorage<any, any>>();
-const promiseCacheStore = new WeakMap<AnyAsyncFunction, Map<unknown, unknown>>();
 
 export interface CacheStorage<KeyType, ValueType> {
 	has: (key: KeyType) => Promise<boolean> | boolean;
@@ -130,7 +129,6 @@ export default function pMemoize<
 	});
 
 	cacheStore.set(memoized, cache);
-	promiseCacheStore.set(memoized, promiseCache);
 
 	return memoized;
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
 		"ava": "^3.15.0",
 		"del-cli": "^4.0.1",
 		"delay": "^5.0.0",
+		"p-defer": "^4.0.0",
+		"p-state": "^1.0.0",
 		"serialize-javascript": "^6.0.0",
 		"ts-node": "^10.3.0",
 		"tsd": "^0.18.0",

--- a/readme.md
+++ b/readme.md
@@ -56,13 +56,6 @@ Type: `object`
 
 See the [`mem` options](https://github.com/sindresorhus/mem#options) in addition to the below option.
 
-##### cachePromiseRejection
-
-Type: `boolean`\
-Default: `false`
-
-Cache rejected promises.
-
 ##### cacheKey
 
 Type: `Function`\

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Useful for speeding up consecutive function calls by caching the result of calls
 
 By default, **only the memoized function's first argument is considered** via strict equality comparison. If you need to cache multiple arguments or cache `object`s *by value*, have a look at alternative [caching strategies](#caching-strategy) below.
 
-This package is similar to [mem](https://github.com/sindresorhus/mem) but with async-specific enhancements; in particular, it allows for asynchronous caches and does not cache rejected promises by default (unless the [`cachePromiseRejection`](#cachePromiseRejection) option is set).
+This package is similar to [mem](https://github.com/sindresorhus/mem) but with async-specific enhancements; in particular, it allows for asynchronous caches and does not cache rejected promises.
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ await memoizedGot('https://sindresorhus.com');
 
 Similar to the [caching strategy for `mem`](https://github.com/sindresorhus/mem#options) with the following exceptions:
 
-- Promises returned from a memoized function will be cached internally and take priority over `cache` if a value exists in both caches. The promise cache does not persist outside of the current instance and properties assigned to a returned promise will not be kept. All cached promises can be cleared with [`pMemoizeClear()`](#pmemoizeclearfn).
-- `.get()` and `.has()` methods on `cache` can return a promise instead of returning a value immediately.
+- Promises returned from a memoized function are locally cached until resolving, when their value is added to `cache`. Special properties assigned to a returned promise will not be kept after resolution and every promise may need to resolve with a serializable object if caching results in a database.
+- `.get()`, `.has()` and `.set()` methods on `cache` can run asynchronously by returning a promise.
 - Instead of `.set()` being provided an object with the properties `value` and `maxAge`, it will only be provided `value` as the first argument. If you want to implement time-based expiry, consider [doing so in `cache`](#time-based-cache-expiration).
 
 ## API
@@ -140,6 +140,18 @@ import got from 'got';
 const cache = new ExpiryMap(10000); // Cached values expire after 10 seconds
 
 const memoizedGot = pMemoize(got, {cache});
+```
+
+### Caching promise rejections
+
+```js
+import pMemoize from 'p-memoize';
+import pReflect from 'p-reflect';
+
+const memoizedGot = pMemoize(async (url, options) => pReflect(got(url, options)));
+
+await memoizedGot('https://example.com');
+// {isFulfilled: true, isRejected: false, value: '...'}
 ```
 
 ## Related

--- a/test.ts
+++ b/test.ts
@@ -64,7 +64,7 @@ test('pending promises are cached', async t => {
 	const promise1 = memoized();
 	t.is(await promiseState(promise1), 'pending');
 
-	const promise2 = memoized(); 
+	const promise2 = memoized();
 	t.is(await promiseState(promise2), 'pending');
 
 	t.is(invocationsCount, 1, 'pending promises are cached');

--- a/test.ts
+++ b/test.ts
@@ -92,7 +92,7 @@ test('pending promises are cached synchronously', async t => {
 	t.is(promise1, promise2);
 
 	resolve(true);
-	
+
 	t.true(await promise1, 'promise is executed');
 	t.true(await promise2, 'promise resolution is propagated');
 
@@ -100,7 +100,7 @@ test('pending promises are cached synchronously', async t => {
 
 	t.true(await memoized(), 'cache is hit');
 	t.true(cache.get(undefined), 'result is cached');
-})
+});
 
 test('cacheKey option', async t => {
 	let index = 0;

--- a/test.ts
+++ b/test.ts
@@ -77,6 +77,31 @@ test('pending promises are cached', async t => {
 	t.true(cache.get(undefined), 'result is cached');
 });
 
+test('pending promises are cached synchronously', async t => {
+	const {promise, resolve} = pDefer();
+	let invocationsCount = 0;
+	const cache = new Map();
+
+	const memoized = pMemoize(async () => {
+		invocationsCount++;
+		return promise;
+	}, {cache});
+
+	const promise1 = memoized();
+	const promise2 = memoized();
+	t.is(promise1, promise2);
+
+	resolve(true);
+	
+	t.true(await promise1, 'promise is executed');
+	t.true(await promise2, 'promise resolution is propagated');
+
+	t.is(invocationsCount, 1, 'pending promises are cached');
+
+	t.true(await memoized(), 'cache is hit');
+	t.true(cache.get(undefined), 'result is cached');
+})
+
 test('cacheKey option', async t => {
 	let index = 0;
 	const fixture = async (..._arguments: any) => index++;


### PR DESCRIPTION
Before, if a function is called twice before the asynchronous cache is checked in the first call, the second call will not recognise the first one. Now, instead of the promise returned from the memoized function being cached, the promise from the function that calls the memoized function is cached.

Makes the function more predictable, though there will always be edge cases and race conditions.

`cachePromiseRejection` is removed because it only happens locally and to have it actually affect the main cache would require us to create a one-size-fits-all solution to serialize errors and a custom storage format to represent fulfilments and rejections. See https://github.com/sindresorhus/p-memoize/pull/47#issuecomment-1153673694

#36 suggests to make all cache methods asynchronous. What do you think?

Fixes #47, Fixes #34