### PR TITLE
Remove the reference to the additional mem options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,8 +54,6 @@ Promise-returning or async function to be memoized.
 
 Type: `object`
 
-See the [`mem` options](https://github.com/sindresorhus/mem#options) in addition to the below option.
-
 ##### cacheKey
 
 Type: `Function`\


### PR DESCRIPTION
Hi,

After reading the readme I followed the "See the `mem` options" link and I gave a try to the `maxAge` feature. I then understood that the `maxAge` feature has been removed from `p-memoize`. I think this was the only option that `mem` had in addition to what is documented in the readme so the link may be confusing now, and it's perhaps better to remove it.

Have a nice day.