### PR TITLE
[BREAKING] Bump type-fest to v4, require Node.js 16

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import mimicFn from 'mimic-fn';
 import type {AsyncReturnType} from 'type-fest';
 
 // TODO: Use the one in `type-fest` when it's added there.
+// See https://github.com/sindresorhus/type-fest/issues/121
 export type AnyAsyncFunction = (...arguments_: readonly any[]) => Promise<unknown | void>;
 
 const cacheStore = new WeakMap<AnyAsyncFunction, CacheStorage<any, any> | false>();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"exports": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=16"
 	},
 	"scripts": {
 		"test": "xo && ava && npm run build && tsd",
@@ -46,7 +46,7 @@
 	],
 	"dependencies": {
 		"mimic-fn": "^4.0.0",
-		"type-fest": "^3.0.0"
+		"type-fest": "^4.0.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",


### PR DESCRIPTION
This PR updates type-fest to v4. Since type-fest v4 itself requires Node.js 16, this is also a breaking change on our side - so this PR also ups the minimum required Node.js version to 16.